### PR TITLE
fix: Remove Sentry DSNs from this repository

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,8 +16,16 @@ A list of all resources available as part of the demo:
 
 You can edit the following files in this directory:
 
-* [`sentry-components.yaml`](./sentry-components.yaml) -- a list of components that have Sentry instrumentation. If some service there is commented out, that means that the vanilla version of the service (meaning, a prebuilt Docker image) will be started. Here you can also specify additional environment variables that will be passed to the running service.
+* [`sentry-components.yaml`](./sentry-components.yaml) -- a list of components that have Sentry instrumentation. If some service there is commented out, that means that the vanilla version of the service (meaning, a prebuilt Docker image) will be started.
 * [`global.yaml`](./global.yaml) -- overrides for the Helm chart that is used to deploy the demo (https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo). Here you can configure things like allocated CPU/memory for each service.
+
+
+### Enable Sentry Instrumentation
+
+To enable Sentry instrumentation for the component, do the following:
+
+1. Uncomment the service section in [`sentry-components.yaml`](./sentry-components.yaml) and provide attribute overrides, if necessasry.
+2. Configure additional non-public parameters (e.g. SENTRY_DSN environment variable) [in this file](https://github.com/getsentry/test-factory/blob/main/k8s/services/workflows/templates/otel-demo/services-secrets.yaml) (private repository).
 
 ## (Re)Deploying Changes
 

--- a/deploy/global.yaml
+++ b/deploy/global.yaml
@@ -1,4 +1,4 @@
-# Overrides for opentelemetry-demo Helm chart (https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo)
+# General (non-Sentry-specific) overrides for opentelemetry-demo Helm chart (https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo)
 ---
 observability:
   otelcol:

--- a/deploy/sentry-components.yaml
+++ b/deploy/sentry-components.yaml
@@ -2,16 +2,16 @@
 #
 # To enable Sentry instrumentation for the component, uncomment the corresponding
 # section below.
-# You can also add additional environment variables (e.g. SENTRY_DSN).
+# You can also provide additional overrides for every enabled services. Check available properties that you
+# can override here: https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-demo/values.yaml
 #
-# NOTE: if you don't override anything for the service, the value of the corresponding
+# NOTE 1: If you don't override anything for the service, the value of the corresponding
 # dictionary key should be "{}" (e.g. "adService: {}"), and NOT empty/null.
+# NOTE 2: "envOverrides" attributes provided in this file will be OVERRIDDEN, and therefore, ignored.
+#
 ---
 components:
-  # adService:
-  #   envOverrides:
-  #     - name: SENTRY_DSN
-  #       value: "test"
+  # adService: {}
 
   # cartService: {}
 
@@ -23,17 +23,9 @@ components:
 
   # featureflagService: {}
 
-  frontend:
-    envOverrides:
-      - name: SENTRY_DSN_SERVER
-        value: "https://a4b60308529c4ce8b54068e220f6d167@o447951.ingest.sentry.io/4504078691663872"
-      - name: NEXT_PUBLIC_SENTRY_DSN_CLIENT
-        value: "https://936fd33064ad4faa8333758bbc4c91a1@o447951.ingest.sentry.io/4504094581063680"
+  frontend: {}
 
-  paymentService:
-    envOverrides:
-      - name: SENTRY_DSN
-        value: "https://9607bc2ca3514d57a8c41b3336498c20@o447951.ingest.sentry.io/4504078555545600"
+  paymentService: {}
 
   # productCatalogService: {}
 


### PR DESCRIPTION
Fixes #5.

## Changes

* Moved (and rotated) Sentry DSN env variables to https://github.com/getsentry/test-factory/blob/main/k8s/services/workflows/templates/otel-demo/services-secrets.yaml
