### PR TITLE
[frontend] Use a build argument in Dockerfile for frontend DSN

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -13,6 +13,9 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY ./pb ./pb
 COPY ./src/frontend .
 
+ARG NEXT_PUBLIC_SENTRY_DSN_CLIENT ''
+ENV NEXT_PUBLIC_SENTRY_DSN_CLIENT=${NEXT_PUBLIC_SENTRY_DSN_CLIENT}
+
 RUN npm run grpc:generate
 RUN npm run build
 


### PR DESCRIPTION
`frontend` service needs to know certain values at the build time, so as a quick fix, adding `NEXT_PUBLIC_SENTRY_DSN_CLIENT` value as a build argument.