### PR TITLE
feat(frontend): Switch to Sentry NextJS SDK on the frontend

### DIFF
--- a/src/frontend/sentry.server.config.js
+++ b/src/frontend/sentry.server.config.js
@@ -8,8 +8,6 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN_SERVER,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,
-  // Use OpenTelemetry instead of Sentry for performance monitoring
-  instrumenter: 'otel',
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/src/frontend/utils/telemetry/Instrumentation.js
+++ b/src/frontend/utils/telemetry/Instrumentation.js
@@ -1,14 +1,10 @@
-const opentelemetry = require("@opentelemetry/sdk-node")
-const { getNodeAutoInstrumentations } = require("@opentelemetry/auto-instrumentations-node")
-const { OTLPTraceExporter } =  require('@opentelemetry/exporter-trace-otlp-grpc')
-
-const { SentrySpanProcessor, SentryPropagator } = require("@sentry/opentelemetry-node");
+const opentelemetry = require('@opentelemetry/sdk-node');
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
 
 const sdk = new opentelemetry.NodeSDK({
   traceExporter: new OTLPTraceExporter(),
-  instrumentations: [ getNodeAutoInstrumentations() ],
-  spanProcessor: new SentrySpanProcessor(),
-  textMapPropagator: new SentryPropagator(),
-})
+  instrumentations: [getNodeAutoInstrumentations()],
+});
 
-sdk.start()
+sdk.start();


### PR DESCRIPTION
Switch to using the NextJS SDK on the frontend.