### PR TITLE
Enable adservice override for deployment

### DIFF
--- a/deploy/sentry-components.yaml
+++ b/deploy/sentry-components.yaml
@@ -11,7 +11,7 @@
 #
 ---
 components:
-  # adService: {}
+  adService: {}
 
   # cartService: {}
 


### PR DESCRIPTION
Vanilla service (prebuilt docker image) is still used after adding Sentry to this demo. This should change it.

# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs](../docs/) folder

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).
