### PR TITLE
fix(frontend): Use SENTRY_ENVIRONMENT explicitly on init

### DIFF
--- a/src/frontend/sentry.server.config.js
+++ b/src/frontend/sentry.server.config.js
@@ -8,6 +8,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN_SERVER,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,
+  environment: process.env.SENTRY_ENVIROMENT,
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/src/frontend/sentry.server.config.js
+++ b/src/frontend/sentry.server.config.js
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN_SERVER,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,
-  environment: process.env.SENTRY_ENVIROMENT,
+  environment: process.env.SENTRY_ENVIRONMENT,
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
Problem: without this change, Sentry SDK will use the value of NODE_ENV env variable as Sentry environment, even if we have SENTRY_ENVIRONMENT variable populated. 

@AbhiPrasad is it expected, actually? Frankly, I'd expect the existing SENTRY_ENVIRONMENT to overpower NODE_ENV, if present.

Relevant code in the SDK: https://github.com/getsentry/sentry-javascript/blob/5f14111443a1a53462c4215f69bceb5059f2a521/packages/node/src/sdk.ts#L143-L145
(I would remove the `options.environment === undefined` check).