### PR TITLE
docs: Add info about staging to deploy/README.md

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,9 +2,27 @@
 
 This folder contains additional configuration for deploying the OpenTelemetry Shop Demo on Sentry's infrastructure. We're using [the official OpenTelemetry Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo) to deploy the demo on our Kubernetes cluster.
 
-The demo is available here: https://otel-demo.testa.getsentry.net/ (internal-only access at the moment).
 
-A list of all resources available as part of the demo:
+## Available Resources
+
+We have two environments at the moment, each having its own set of supporting services.
+
+**Note**: all links are currently accessible by Sentry employees only.
+
+### Staging
+
+This environment used for development and testing.
+
+* Webstore: https://otel-demo-staging.testa.getsentry.net/
+* Grafana: https://otel-demo-staging.testa.getsentry.net/grafana/
+* Feature Flags UI: https://otel-demo-staging.testa.getsentry.net/feature/
+* Load Generator UI: https://otel-demo-staging.testa.getsentry.net/loadgen/
+* Jaeger UI: https://otel-demo-staging.testa.getsentry.net/jaeger/ui/
+
+
+### Production
+
+This environment can be used for demos, and should be considered "stable".
 
 * Webstore: https://otel-demo.testa.getsentry.net/
 * Grafana: https://otel-demo.testa.getsentry.net/grafana/
@@ -29,15 +47,21 @@ To enable Sentry instrumentation for the component, do the following:
 
 ## (Re)Deploying Changes
 
-At the moment we maintain a single demo environment, reachable via a fixed URL (https://otel-demo.testa.getsentry.net/). The environment can be redeployed via our [instance of Argo Workflows](https://run.testa.getsentry.net/). It works as follows:
+At the moment we maintain two demo environments:
+* Staging: https://otel-demo-staging.testa.getsentry.net/
+* Production: https://otel-demo.testa.getsentry.net/
+
+The environments can be redeployed via our [instance of Argo Workflows](https://run.testa.getsentry.net/). It works as follows:
 
 1. Go to https://run.testa.getsentry.net/ (internal-only).
-2. Click "+ Submit New Workflow" in the upper left corner.
-3. Select "opentelemetry-demo-deploy" workflow.
-4. Specify the git revision (branch, commit, etc.) of https://github.com/getsentry/opentelemetry-demo repository that you want to deploy.
-5. Click "+ Submit".
+1. Click "+ Submit New Workflow" in the upper left corner.
+1. Select "opentelemetry-demo-deploy" workflow.
+1. Specify the git revision (branch, commit, etc.) of https://github.com/getsentry/opentelemetry-demo repository that you want to deploy.
+1. Change the environment via the dropdown, if necessary.
+1. Click `+ Submit`.
 
-<img src="https://user-images.githubusercontent.com/1120468/203613869-d6cb32f5-d226-4392-94e5-80f3b73ce360.png" height="400" />
+<img src="https://user-images.githubusercontent.com/1120468/207635202-00cf09e0-edbd-47e1-a61b-765ad37c4764.png" width="700" />
+
 
 In a few minutes the environment will be recreated.
 


### PR DESCRIPTION
We now have two environments, so changing deploy/README.md to reflect that.

Closes #33.