### PR TITLE
ref: Prepare for the Helm chart update, add nodeSelector/tolerations

### DIFF
--- a/deploy/global.yaml
+++ b/deploy/global.yaml
@@ -37,7 +37,18 @@ jaeger:
       limits:
         memory: 350Mi
 
-# TODO: add resource requests/limits and tolerations for all components here
+default:
+  # Run all demo components on a separate node pool
+  schedulingRules:
+    nodeSelector:
+      nodepool.sentry.io/name: otel-demo
+    tolerations:
+      - key: "nodepool-dedicated"
+        operator: "Equal"
+        value: "otel-demo"
+        effect: "NoSchedule"
+
+# Demo components
 components:
   adService:
     resources:

--- a/deploy/global.yaml
+++ b/deploy/global.yaml
@@ -9,11 +9,6 @@ observability:
     enabled: true
   jaeger:
     enabled: true
-    resources:
-      requests:
-        cpu: 50m
-      limits:
-        memory: 350Mi
 
 prometheus:
   rbac:
@@ -33,6 +28,14 @@ grafana:
   rbac:
     create: false
     pspEnabled: false
+
+jaeger:
+  allInOne:
+    resources:
+      requests:
+        cpu: 50m
+      limits:
+        memory: 350Mi
 
 # TODO: add resource requests/limits and tolerations for all components here
 components:

--- a/deploy/global.yaml
+++ b/deploy/global.yaml
@@ -54,34 +54,52 @@ components:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      # Here and below: this is a workaround for an existing issue in the Helm chart (to be fixed).
+      # The final values for nodeSelector and tolerations will still be takend from "default".
+      nodeSelector: {}
   cartService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   checkoutService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   currencyService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   emailService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   featureflagService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   ffsPostgres:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   frontend:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   frontendProxy:
     resources:
       requests:
@@ -89,31 +107,47 @@ components:
         memory: 100Mi
       limits:
         memory: 100Mi
+    schedulingRules:
+      nodeSelector: {}
   loadgenerator:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   paymentService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   productCatalogService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   quoteService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   recommendationService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   redis:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}
   shippingService:
     resources:
       requests:
         cpu: 50m
+    schedulingRules:
+      nodeSelector: {}


### PR DESCRIPTION
Summary: 

1. Add nodeSelector/tolerations stanzas to control the node pools where the services are running. The goal is to run all otel-demo components on a separate node pool, to isolate them from all other workloads in our current Kubernetes cluster.
2. Move Jaeger configuration to a top-level "jaeger" attribute. This is needed to update the chart we're using (https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo) to a newer version, where Jaeger is installed a 3rd party chart.