### PR TITLE
feat: Update to the latest Helm chart and add new services

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,7 +4,6 @@ This folder contains additional configuration for deploying the
 OpenTelemetry Shop Demo on Sentry's infrastructure. We're using
 [the official OpenTelemetry Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo)
 to deploy the demo on our Kubernetes cluster.
-
 ## Available Resources
 
 We have two environments at the moment, each having its own set of supporting services.
@@ -35,6 +34,8 @@ This environment can be used for demos, and should be considered "stable".
 
 You can edit the following files in this directory:
 
+- [`meta.yaml`](./meta.yaml) -- contains various meta configuration about the
+  deployment, e.g. the currently used version of the Helm chart.
 - [`sentry-components.yaml`](./sentry-components.yaml) -- a list of components
   that have Sentry instrumentation. If some service there is commented out, that
   means that the vanilla version of the service (meaning, a prebuilt Docker image)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,6 +4,7 @@ This folder contains additional configuration for deploying the
 OpenTelemetry Shop Demo on Sentry's infrastructure. We're using
 [the official OpenTelemetry Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo)
 to deploy the demo on our Kubernetes cluster.
+
 ## Available Resources
 
 We have two environments at the moment, each having its own set of supporting services.

--- a/deploy/global.yaml
+++ b/deploy/global.yaml
@@ -50,56 +50,44 @@ default:
 
 # Demo components
 components:
+  # Main services
+
+  accountingService:
+    resources:
+      requests:
+        cpu: 50m
   adService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      # Here and below: this is a workaround for an existing issue in the Helm chart (to be fixed).
-      # The final values for nodeSelector and tolerations will still be takend from "default".
-      nodeSelector: {}
   cartService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   checkoutService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   currencyService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   emailService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   featureflagService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
-  ffsPostgres:
+  frauddetectionService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   frontend:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   frontendProxy:
     resources:
       requests:
@@ -107,47 +95,42 @@ components:
         memory: 100Mi
       limits:
         memory: 100Mi
-    schedulingRules:
-      nodeSelector: {}
   loadgenerator:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   paymentService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   productCatalogService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   quoteService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   recommendationService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
-  redis:
-    resources:
-      requests:
-        cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
   shippingService:
     resources:
       requests:
         cpu: 50m
-    schedulingRules:
-      nodeSelector: {}
+
+  # Supporting services and data storages
+
+  ffsPostgres:
+    resources:
+      requests:
+        cpu: 50m
+  kafka:
+    resources:
+      requests:
+        cpu: 50m
+  redis:
+    resources:
+      requests:
+        cpu: 50m

--- a/deploy/global.yaml
+++ b/deploy/global.yaml
@@ -11,6 +11,7 @@ observability:
     enabled: true
 
 prometheus:
+  # TODO(tonyo): run in the otel nodepool
   rbac:
     create: false
   serverFiles:
@@ -25,11 +26,13 @@ prometheus:
             - targets:
                 - "otel-demo-otelcol:8888"
 grafana:
+  # TODO(tonyo): run in the otel nodepool
   rbac:
     create: false
     pspEnabled: false
 
 jaeger:
+  # TODO(tonyo): run in the otel nodepool
   allInOne:
     resources:
       requests:

--- a/deploy/meta.yaml
+++ b/deploy/meta.yaml
@@ -1,0 +1,5 @@
+# This configuration file contains meta information for the Sentry-specific opentelemetry-demo deployments.
+
+# Version of the Helm chart to use.
+# Chart: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo
+helm_chart_version: "0.15.4"

--- a/deploy/meta.yaml
+++ b/deploy/meta.yaml
@@ -2,4 +2,4 @@
 
 # Version of the Helm chart to use.
 # Chart: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo
-helm_chart_version: "0.15.3"
+helm_chart_version: "0.15.4"

--- a/deploy/meta.yaml
+++ b/deploy/meta.yaml
@@ -2,4 +2,4 @@
 
 # Version of the Helm chart to use.
 # Chart: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo
-helm_chart_version: "0.15.4"
+helm_chart_version: "0.15.3"

--- a/deploy/sentry-components.yaml
+++ b/deploy/sentry-components.yaml
@@ -11,6 +11,8 @@
 #
 ---
 components:
+  # accountingService: {}
+
   adService: {}
 
   # cartService: {}
@@ -22,6 +24,8 @@ components:
   # emailService: {}
 
   # featureflagService: {}
+
+  # frauddetectionService: {}
 
   frontend: {}
 


### PR DESCRIPTION
In this PR we do a few things:

* Add stubs for two new services: `accountingService` and `frauddetectionService`
* Clean-up `deploy/global.yaml`, since [my fix](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/575) has been merged to the opentelemetry-charts repo.
* Adds `deploy/meta.yaml`. In this file we can now specify the helm chart version, that will be picked up by the Argo workflow that deploys the demo. This will simplify updates and merges with the upstream: for example, it's possible now to specify the version of the Helm opentelemetry-demo chart that will be used.

Closes https://github.com/getsentry/opentelemetry-demo/issues/40