### PR TITLE
fix(emailservice): Enable emailservice custom builds

### DIFF
--- a/deploy/sentry-components.yaml
+++ b/deploy/sentry-components.yaml
@@ -21,7 +21,7 @@ components:
 
   # currencyService: {}
 
-  # emailService: {}
+  emailService: {}
 
   # featureflagService: {}
 


### PR DESCRIPTION
Basically custom (Sentry-enabled) builds were not enabled for the email service, so we had no traces in prod.