### PR TITLE
feat: Bump Go services to sentry-go v0.18.0

### DIFF
--- a/src/accountingservice/go.mod
+++ b/src/accountingservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.17.1-0.20230120155554-ab628b4833c1
-	github.com/getsentry/sentry-go/otel v0.0.0-20230120155554-ab628b4833c1
+	github.com/getsentry/sentry-go v0.18.0
+	github.com/getsentry/sentry-go/otel v0.18.0
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.3
 	go.opentelemetry.io/otel v1.11.2

--- a/src/accountingservice/go.sum
+++ b/src/accountingservice/go.sum
@@ -71,10 +71,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.17.1-0.20230120155554-ab628b4833c1 h1:sLOvmmcMe0lCI92+SFF9kjWYQXTBkPfeuO73HgPPJPE=
-github.com/getsentry/sentry-go v0.17.1-0.20230120155554-ab628b4833c1/go.mod h1:B82dxtBvxG0KaPD8/hfSV+VcHD+Lg/xUS4JuQn1P4cM=
-github.com/getsentry/sentry-go/otel v0.0.0-20230120155554-ab628b4833c1 h1:kzPwJ+boN+HeISKk+2tobOndPM2uxL6z/SbmVinhvkg=
-github.com/getsentry/sentry-go/otel v0.0.0-20230120155554-ab628b4833c1/go.mod h1:Gm5xGZ6z0ikKsdaf0eARRy1SO5H/fwSUt/4wkQe2y/E=
+github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
+github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnRJRLTXZr51aKQ=
+github.com/getsentry/sentry-go/otel v0.18.0 h1:ub8bv6nk8cjttzicpVDNpWkHumOzKs4tdV/cTyZTdlk=
+github.com/getsentry/sentry-go/otel v0.18.0/go.mod h1:EwjAuzAHdSM+F7qXsYsJLtbZs+qyPAfu55FU0UpbRqE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.17.1-0.20230120155554-ab628b4833c1
-	github.com/getsentry/sentry-go/otel v0.0.0-20230120155554-ab628b4833c1
+	github.com/getsentry/sentry-go v0.18.0
+	github.com/getsentry/sentry-go/otel v0.18.0
 	github.com/google/uuid v1.3.0
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.2

--- a/src/checkoutservice/go.sum
+++ b/src/checkoutservice/go.sum
@@ -92,10 +92,10 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.17.1-0.20230120155554-ab628b4833c1 h1:sLOvmmcMe0lCI92+SFF9kjWYQXTBkPfeuO73HgPPJPE=
-github.com/getsentry/sentry-go v0.17.1-0.20230120155554-ab628b4833c1/go.mod h1:B82dxtBvxG0KaPD8/hfSV+VcHD+Lg/xUS4JuQn1P4cM=
-github.com/getsentry/sentry-go/otel v0.0.0-20230120155554-ab628b4833c1 h1:kzPwJ+boN+HeISKk+2tobOndPM2uxL6z/SbmVinhvkg=
-github.com/getsentry/sentry-go/otel v0.0.0-20230120155554-ab628b4833c1/go.mod h1:Gm5xGZ6z0ikKsdaf0eARRy1SO5H/fwSUt/4wkQe2y/E=
+github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
+github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnRJRLTXZr51aKQ=
+github.com/getsentry/sentry-go/otel v0.18.0 h1:ub8bv6nk8cjttzicpVDNpWkHumOzKs4tdV/cTyZTdlk=
+github.com/getsentry/sentry-go/otel v0.18.0/go.mod h1:EwjAuzAHdSM+F7qXsYsJLtbZs+qyPAfu55FU0UpbRqE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/productcatalogservice/go.mod
+++ b/src/productcatalogservice/go.mod
@@ -10,8 +10,8 @@ require (
 )
 
 require (
-	github.com/getsentry/sentry-go v0.17.1-0.20230120155554-ab628b4833c1
-	github.com/getsentry/sentry-go/otel v0.0.0-20230120155554-ab628b4833c1
+	github.com/getsentry/sentry-go v0.18.0
+	github.com/getsentry/sentry-go/otel v0.18.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.34.0
 	go.opentelemetry.io/otel/metric v0.34.0

--- a/src/productcatalogservice/go.sum
+++ b/src/productcatalogservice/go.sum
@@ -63,10 +63,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/getsentry/sentry-go v0.17.1-0.20230120155554-ab628b4833c1 h1:sLOvmmcMe0lCI92+SFF9kjWYQXTBkPfeuO73HgPPJPE=
-github.com/getsentry/sentry-go v0.17.1-0.20230120155554-ab628b4833c1/go.mod h1:B82dxtBvxG0KaPD8/hfSV+VcHD+Lg/xUS4JuQn1P4cM=
-github.com/getsentry/sentry-go/otel v0.0.0-20230120155554-ab628b4833c1 h1:kzPwJ+boN+HeISKk+2tobOndPM2uxL6z/SbmVinhvkg=
-github.com/getsentry/sentry-go/otel v0.0.0-20230120155554-ab628b4833c1/go.mod h1:Gm5xGZ6z0ikKsdaf0eARRy1SO5H/fwSUt/4wkQe2y/E=
+github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
+github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnRJRLTXZr51aKQ=
+github.com/getsentry/sentry-go/otel v0.18.0 h1:ub8bv6nk8cjttzicpVDNpWkHumOzKs4tdV/cTyZTdlk=
+github.com/getsentry/sentry-go/otel v0.18.0/go.mod h1:EwjAuzAHdSM+F7qXsYsJLtbZs+qyPAfu55FU0UpbRqE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
Initial OTel support has been released in sentry-go v0.18.0, so we can update the following services:
* checkout service
* accounting service
* product catalog service