### PR TITLE
fix(paymentservice): Give more memory

### DIFF
--- a/deploy/global.yaml
+++ b/deploy/global.yaml
@@ -106,6 +106,9 @@ components:
     resources:
       requests:
         cpu: 50m
+        memory: 200Mi
+      limits:
+        memory: 200Mi
   productCatalogService:
     resources:
       requests:

--- a/deploy/meta.yaml
+++ b/deploy/meta.yaml
@@ -2,4 +2,4 @@
 
 # Version of the Helm chart to use.
 # Chart: https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo
-helm_chart_version: "0.15.4"
+helm_chart_version: "0.18.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -389,7 +389,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 70M
+          memory: 200M
     restart: unless-stopped
     ports:
       - "${PAYMENT_SERVICE_PORT}"


### PR DESCRIPTION
After recent updates, payment service is getting OOMs, so giving it more memory.

Bumping the Helm chart version should also help with adservice that's crashing now.