### PR TITLE
feat: Enable local variables feature for Node services

### DIFF
--- a/src/frontend/sentry.server.config.js
+++ b/src/frontend/sentry.server.config.js
@@ -13,6 +13,7 @@ Sentry.init({
   tracesSampleRate: 1.0,
   // profilesSampleRate: 1.0,
   environment: process.env.SENTRY_ENVIRONMENT,
+  includeLocalVariables: true,
   // integrations: [new ProfilingIntegration()],
   // ...
   // Note: if you want to override the automatic release value, do not set a

--- a/src/paymentservice/sentry.js
+++ b/src/paymentservice/sentry.js
@@ -10,6 +10,7 @@ function initSentry() {
     // profilesSampleRate: 1.0,
     // set the instrumenter to use OpenTelemetry instead of Sentry
     instrumenter: "otel",
+    includeLocalVariables: true,
     // integrations: [new ProfilingIntegration()],
     // ...
   });


### PR DESCRIPTION
Services affected:
* frontend (server side)
* paymenteservice

In both services we use sentry/node==7.32.0, which should support the [Node local variables feature](https://blog.sentry.io/2023/02/01/local-variables-for-nodejs-in-sentry/).