### PR TITLE
guard against parent span not being defined

### DIFF
--- a/src/frontend/sentry.server.config.js
+++ b/src/frontend/sentry.server.config.js
@@ -14,6 +14,11 @@ Sentry.init({
   // profilesSampleRate: 1.0,
   environment: process.env.SENTRY_ENVIRONMENT,
   includeLocalVariables: true,
+  integrations: [
+    new Sentry.Integrations.LocalVariables({
+      captureAllExceptions: true,
+    }),
+  ],
   beforeSendTransaction: transaction => {
     console.log(JSON.stringify(transaction, null, 2));
     return transaction;

--- a/src/frontend/utils/telemetry/InstrumentationMiddleware.ts
+++ b/src/frontend/utils/telemetry/InstrumentationMiddleware.ts
@@ -55,8 +55,10 @@ async function runWithSpan(parentSpan: Span, fn: () => Promise<unknown>) {
   try {
     return await context.with(ctx, fn);
   } catch (error) {
-    parentSpan.recordException(error as Exception);
-    parentSpan.setStatus({ code: SpanStatusCode.ERROR });
+    if (parentSpan) {
+      parentSpan.recordException(error as Exception);
+      parentSpan.setStatus({ code: SpanStatusCode.ERROR });
+    }
 
     throw error;
   }


### PR DESCRIPTION
Also set up our local variables integration to set up handled exceptions: https://docs.sentry.io/platforms/node/configuration/integrations/default-integrations/#contextlines