### PR TITLE
fix(frontend-node): Disable local variables integration due to a memory leak

### DIFF
--- a/src/frontend/sentry.server.config.js
+++ b/src/frontend/sentry.server.config.js
@@ -19,15 +19,6 @@ Sentry.init({
       captureAllExceptions: true,
     }),
   ],
-  beforeSendTransaction: transaction => {
-    console.log(JSON.stringify(transaction, null, 2));
-    return transaction;
-  },
-  beforeBreadcrumb: breadcrumb => {
-    if (breadcrumb.category === 'console') {
-      return null;
-    }
-  },
   // integrations: [new ProfilingIntegration()],
   // ...
   // Note: if you want to override the automatic release value, do not set a

--- a/src/frontend/sentry.server.config.js
+++ b/src/frontend/sentry.server.config.js
@@ -13,12 +13,12 @@ Sentry.init({
   tracesSampleRate: 1.0,
   // profilesSampleRate: 1.0,
   environment: process.env.SENTRY_ENVIRONMENT,
-  includeLocalVariables: true,
-  integrations: [
-    new Sentry.Integrations.LocalVariables({
-      captureAllExceptions: true,
-    }),
-  ],
+  // includeLocalVariables: true,
+  // integrations: [
+  //   new Sentry.Integrations.LocalVariables({
+  //     captureAllExceptions: true,
+  //   }),
+  // ],
   // integrations: [new ProfilingIntegration()],
   // ...
   // Note: if you want to override the automatic release value, do not set a


### PR DESCRIPTION
Temporarily disabling LocalVariables integration because it seems to be introducing a memory leak.
Also removing debug output we introduced a few commits ago.