### PR TITLE
feat: Update sentry-go to 0.21.0

### DIFF
--- a/src/accountingservice/go.mod
+++ b/src/accountingservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af
-	github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af
+	github.com/getsentry/sentry-go v0.21.0
+	github.com/getsentry/sentry-go/otel v0.21.0
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.3
 	go.opentelemetry.io/otel v1.11.2

--- a/src/accountingservice/go.mod
+++ b/src/accountingservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.20.0
-	github.com/getsentry/sentry-go/otel v0.20.0
+	github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af
+	github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.3
 	go.opentelemetry.io/otel v1.11.2

--- a/src/accountingservice/go.sum
+++ b/src/accountingservice/go.sum
@@ -71,10 +71,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af h1:yqkuRYkdOijB0qKTnaIcSNP6UxdYEoTdu86M1meMwws=
-github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af h1:PhVooRq3sjVXfqtowUSTH7UxkPbizOASsfwe/URvHts=
-github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:fqjlwGX+Rp35DvCuQOz4Mm8K3RBaDt6BGKENpV0+tnk=
+github.com/getsentry/sentry-go v0.21.0 h1:c9l5F1nPF30JIppulk4veau90PK6Smu3abgVtVQWon4=
+github.com/getsentry/sentry-go v0.21.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.21.0 h1:0GJViLdYYDWdSJLyFe8JMx2Aq3TOVZ4OFhn5KGDjyYQ=
+github.com/getsentry/sentry-go/otel v0.21.0/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/accountingservice/go.sum
+++ b/src/accountingservice/go.sum
@@ -71,10 +71,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.20.0 h1:bwXW98iMRIWxn+4FgPW7vMrjmbym6HblXALmhjHmQaQ=
-github.com/getsentry/sentry-go v0.20.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.20.0 h1:xGTxH48rMbGzbNIg2Ick+Zw+M1GizC/2LKOEco6bvLw=
-github.com/getsentry/sentry-go/otel v0.20.0/go.mod h1:fqjlwGX+Rp35DvCuQOz4Mm8K3RBaDt6BGKENpV0+tnk=
+github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af h1:yqkuRYkdOijB0qKTnaIcSNP6UxdYEoTdu86M1meMwws=
+github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af h1:PhVooRq3sjVXfqtowUSTH7UxkPbizOASsfwe/URvHts=
+github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:fqjlwGX+Rp35DvCuQOz4Mm8K3RBaDt6BGKENpV0+tnk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af
-	github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af
+	github.com/getsentry/sentry-go v0.21.0
+	github.com/getsentry/sentry-go/otel v0.21.0
 	github.com/google/uuid v1.3.0
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.2

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.20.0
-	github.com/getsentry/sentry-go/otel v0.20.0
+	github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af
+	github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af
 	github.com/google/uuid v1.3.0
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.2

--- a/src/checkoutservice/go.sum
+++ b/src/checkoutservice/go.sum
@@ -92,10 +92,10 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af h1:yqkuRYkdOijB0qKTnaIcSNP6UxdYEoTdu86M1meMwws=
-github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af h1:PhVooRq3sjVXfqtowUSTH7UxkPbizOASsfwe/URvHts=
-github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:fqjlwGX+Rp35DvCuQOz4Mm8K3RBaDt6BGKENpV0+tnk=
+github.com/getsentry/sentry-go v0.21.0 h1:c9l5F1nPF30JIppulk4veau90PK6Smu3abgVtVQWon4=
+github.com/getsentry/sentry-go v0.21.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.21.0 h1:0GJViLdYYDWdSJLyFe8JMx2Aq3TOVZ4OFhn5KGDjyYQ=
+github.com/getsentry/sentry-go/otel v0.21.0/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/checkoutservice/go.sum
+++ b/src/checkoutservice/go.sum
@@ -92,10 +92,10 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.20.0 h1:bwXW98iMRIWxn+4FgPW7vMrjmbym6HblXALmhjHmQaQ=
-github.com/getsentry/sentry-go v0.20.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.20.0 h1:xGTxH48rMbGzbNIg2Ick+Zw+M1GizC/2LKOEco6bvLw=
-github.com/getsentry/sentry-go/otel v0.20.0/go.mod h1:fqjlwGX+Rp35DvCuQOz4Mm8K3RBaDt6BGKENpV0+tnk=
+github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af h1:yqkuRYkdOijB0qKTnaIcSNP6UxdYEoTdu86M1meMwws=
+github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af h1:PhVooRq3sjVXfqtowUSTH7UxkPbizOASsfwe/URvHts=
+github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:fqjlwGX+Rp35DvCuQOz4Mm8K3RBaDt6BGKENpV0+tnk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/productcatalogservice/go.mod
+++ b/src/productcatalogservice/go.mod
@@ -10,8 +10,8 @@ require (
 )
 
 require (
-	github.com/getsentry/sentry-go v0.20.0
-	github.com/getsentry/sentry-go/otel v0.20.0
+	github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af
+	github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.34.0
 	go.opentelemetry.io/otel/metric v0.34.0

--- a/src/productcatalogservice/go.mod
+++ b/src/productcatalogservice/go.mod
@@ -10,8 +10,8 @@ require (
 )
 
 require (
-	github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af
-	github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af
+	github.com/getsentry/sentry-go v0.21.0
+	github.com/getsentry/sentry-go/otel v0.21.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.34.0
 	go.opentelemetry.io/otel/metric v0.34.0

--- a/src/productcatalogservice/go.sum
+++ b/src/productcatalogservice/go.sum
@@ -63,10 +63,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/getsentry/sentry-go v0.20.0 h1:bwXW98iMRIWxn+4FgPW7vMrjmbym6HblXALmhjHmQaQ=
-github.com/getsentry/sentry-go v0.20.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.20.0 h1:xGTxH48rMbGzbNIg2Ick+Zw+M1GizC/2LKOEco6bvLw=
-github.com/getsentry/sentry-go/otel v0.20.0/go.mod h1:fqjlwGX+Rp35DvCuQOz4Mm8K3RBaDt6BGKENpV0+tnk=
+github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af h1:yqkuRYkdOijB0qKTnaIcSNP6UxdYEoTdu86M1meMwws=
+github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af h1:PhVooRq3sjVXfqtowUSTH7UxkPbizOASsfwe/URvHts=
+github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:fqjlwGX+Rp35DvCuQOz4Mm8K3RBaDt6BGKENpV0+tnk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/productcatalogservice/go.sum
+++ b/src/productcatalogservice/go.sum
@@ -63,10 +63,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af h1:yqkuRYkdOijB0qKTnaIcSNP6UxdYEoTdu86M1meMwws=
-github.com/getsentry/sentry-go v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af h1:PhVooRq3sjVXfqtowUSTH7UxkPbizOASsfwe/URvHts=
-github.com/getsentry/sentry-go/otel v0.20.1-0.20230508091029-ce90464c17af/go.mod h1:fqjlwGX+Rp35DvCuQOz4Mm8K3RBaDt6BGKENpV0+tnk=
+github.com/getsentry/sentry-go v0.21.0 h1:c9l5F1nPF30JIppulk4veau90PK6Smu3abgVtVQWon4=
+github.com/getsentry/sentry-go v0.21.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.21.0 h1:0GJViLdYYDWdSJLyFe8JMx2Aq3TOVZ4OFhn5KGDjyYQ=
+github.com/getsentry/sentry-go/otel v0.21.0/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
https://github.com/getsentry/sentry-go/releases/tag/v0.21.0