### PR TITLE
feat: Bump sentry-go to v0.22.0, enable profiling

### DIFF
--- a/scripts/reinstall_sentry_go_all_services.sh
+++ b/scripts/reinstall_sentry_go_all_services.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+### This script installs the provided version of "sentry-go" library to all
+### Go-based services (version "master" is used by default).
+set -euxo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+unset GOROOT
+
+VERSION="${1:-master}"
+
+SERVICES="checkoutservice productcatalogservice accountingservice"
+
+for s in $SERVICES; do
+  cd $SCRIPT_DIR/../src/$s
+  go get github.com/getsentry/sentry-go@$VERSION
+  go get github.com/getsentry/sentry-go/otel@$VERSION
+  go mod tidy
+done

--- a/src/accountingservice/go.mod
+++ b/src/accountingservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b
-	github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b
+	github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c
+	github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.3
 	go.opentelemetry.io/otel v1.11.2

--- a/src/accountingservice/go.mod
+++ b/src/accountingservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c
-	github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c
+	github.com/getsentry/sentry-go v0.22.0
+	github.com/getsentry/sentry-go/otel v0.22.0
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.3
 	go.opentelemetry.io/otel v1.11.2

--- a/src/accountingservice/go.mod
+++ b/src/accountingservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.21.0
-	github.com/getsentry/sentry-go/otel v0.21.0
+	github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b
+	github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.3
 	go.opentelemetry.io/otel v1.11.2

--- a/src/accountingservice/go.sum
+++ b/src/accountingservice/go.sum
@@ -71,10 +71,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.21.0 h1:c9l5F1nPF30JIppulk4veau90PK6Smu3abgVtVQWon4=
-github.com/getsentry/sentry-go v0.21.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.21.0 h1:0GJViLdYYDWdSJLyFe8JMx2Aq3TOVZ4OFhn5KGDjyYQ=
-github.com/getsentry/sentry-go/otel v0.21.0/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
+github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b h1:AVhL1yoan/25csLmQ4/AaqnfZpDckyIogupD2AB8ErQ=
+github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b h1:j+ft0dmibZkW/LOgdeptppZjmFV62ttNOpDt4iZt2S0=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/accountingservice/go.sum
+++ b/src/accountingservice/go.sum
@@ -71,10 +71,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b h1:AVhL1yoan/25csLmQ4/AaqnfZpDckyIogupD2AB8ErQ=
-github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b h1:j+ft0dmibZkW/LOgdeptppZjmFV62ttNOpDt4iZt2S0=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
+github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c h1:T03Z7RuSyKvG+x2+sBbGdIChgQAFXbBAQCQC/y+1ap0=
+github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c h1:bqClvCTgEJeDUuL0aV3VzIxRQtVfze/lKOBL7WQZpLw=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/accountingservice/go.sum
+++ b/src/accountingservice/go.sum
@@ -71,10 +71,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c h1:T03Z7RuSyKvG+x2+sBbGdIChgQAFXbBAQCQC/y+1ap0=
-github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c h1:bqClvCTgEJeDUuL0aV3VzIxRQtVfze/lKOBL7WQZpLw=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
+github.com/getsentry/sentry-go v0.22.0 h1:XNX9zKbv7baSEI65l+H1GEJgSeIC1c7EN5kluWaP6dM=
+github.com/getsentry/sentry-go v0.22.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.22.0 h1:6ioHUtWk5IVqdIZppUI0hhm0f/+XTsT+yu6xqWCYULw=
+github.com/getsentry/sentry-go/otel v0.22.0/go.mod h1:V6d/p0sKN9OLyFeaQAx8RIc/2Uf3w6h65d+Pzx3qkmo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/accountingservice/main.go
+++ b/src/accountingservice/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-demo/src/accountingservice/kafka"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/getsentry/sentry-go/otel"
+	sentryotel "github.com/getsentry/sentry-go/otel"
 )
 
 var log *logrus.Logger
@@ -89,10 +89,11 @@ func initTracerProvider() (*sdktrace.TracerProvider, error) {
 
 func main() {
 	sentry.Init(sentry.ClientOptions{
-		Dsn:              "",
-		EnableTracing:    true,
-		TracesSampleRate: 1.0,
-		Debug:            true,
+		Dsn:                "",
+		EnableTracing:      true,
+		TracesSampleRate:   1.0,
+		ProfilesSampleRate: 1.0,
+		Debug:              true,
 	})
 
 	tp, err := initTracerProvider()

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c
-	github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c
+	github.com/getsentry/sentry-go v0.22.0
+	github.com/getsentry/sentry-go/otel v0.22.0
 	github.com/google/uuid v1.3.0
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.2

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.21.0
-	github.com/getsentry/sentry-go/otel v0.21.0
+	github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b
+	github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b
 	github.com/google/uuid v1.3.0
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.2

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.37.2
-	github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b
-	github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b
+	github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c
+	github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c
 	github.com/google/uuid v1.3.0
 	github.com/sirupsen/logrus v1.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.36.2

--- a/src/checkoutservice/go.sum
+++ b/src/checkoutservice/go.sum
@@ -92,10 +92,10 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c h1:T03Z7RuSyKvG+x2+sBbGdIChgQAFXbBAQCQC/y+1ap0=
-github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c h1:bqClvCTgEJeDUuL0aV3VzIxRQtVfze/lKOBL7WQZpLw=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
+github.com/getsentry/sentry-go v0.22.0 h1:XNX9zKbv7baSEI65l+H1GEJgSeIC1c7EN5kluWaP6dM=
+github.com/getsentry/sentry-go v0.22.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.22.0 h1:6ioHUtWk5IVqdIZppUI0hhm0f/+XTsT+yu6xqWCYULw=
+github.com/getsentry/sentry-go/otel v0.22.0/go.mod h1:V6d/p0sKN9OLyFeaQAx8RIc/2Uf3w6h65d+Pzx3qkmo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/checkoutservice/go.sum
+++ b/src/checkoutservice/go.sum
@@ -92,10 +92,10 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.21.0 h1:c9l5F1nPF30JIppulk4veau90PK6Smu3abgVtVQWon4=
-github.com/getsentry/sentry-go v0.21.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.21.0 h1:0GJViLdYYDWdSJLyFe8JMx2Aq3TOVZ4OFhn5KGDjyYQ=
-github.com/getsentry/sentry-go/otel v0.21.0/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
+github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b h1:AVhL1yoan/25csLmQ4/AaqnfZpDckyIogupD2AB8ErQ=
+github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b h1:j+ft0dmibZkW/LOgdeptppZjmFV62ttNOpDt4iZt2S0=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/checkoutservice/go.sum
+++ b/src/checkoutservice/go.sum
@@ -92,10 +92,10 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b h1:AVhL1yoan/25csLmQ4/AaqnfZpDckyIogupD2AB8ErQ=
-github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b h1:j+ft0dmibZkW/LOgdeptppZjmFV62ttNOpDt4iZt2S0=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
+github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c h1:T03Z7RuSyKvG+x2+sBbGdIChgQAFXbBAQCQC/y+1ap0=
+github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c h1:bqClvCTgEJeDUuL0aV3VzIxRQtVfze/lKOBL7WQZpLw=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -55,7 +55,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-demo/src/checkoutservice/money"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/getsentry/sentry-go/otel"
+	sentryotel "github.com/getsentry/sentry-go/otel"
 )
 
 var log *logrus.Logger
@@ -141,10 +141,11 @@ type checkoutService struct {
 
 func main() {
 	sentry.Init(sentry.ClientOptions{
-		Dsn:              "",
-		EnableTracing:    true,
-		TracesSampleRate: 1.0,
-		Debug:            true,
+		Dsn:                "",
+		EnableTracing:      true,
+		TracesSampleRate:   1.0,
+		ProfilesSampleRate: 1.0,
+		Debug:              true,
 	})
 
 	var port string

--- a/src/productcatalogservice/go.mod
+++ b/src/productcatalogservice/go.mod
@@ -10,8 +10,8 @@ require (
 )
 
 require (
-	github.com/getsentry/sentry-go v0.21.0
-	github.com/getsentry/sentry-go/otel v0.21.0
+	github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b
+	github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.34.0
 	go.opentelemetry.io/otel/metric v0.34.0

--- a/src/productcatalogservice/go.mod
+++ b/src/productcatalogservice/go.mod
@@ -10,8 +10,8 @@ require (
 )
 
 require (
-	github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b
-	github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b
+	github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c
+	github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.34.0
 	go.opentelemetry.io/otel/metric v0.34.0

--- a/src/productcatalogservice/go.mod
+++ b/src/productcatalogservice/go.mod
@@ -10,8 +10,8 @@ require (
 )
 
 require (
-	github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c
-	github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c
+	github.com/getsentry/sentry-go v0.22.0
+	github.com/getsentry/sentry-go/otel v0.22.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.34.0
 	go.opentelemetry.io/otel/metric v0.34.0

--- a/src/productcatalogservice/go.sum
+++ b/src/productcatalogservice/go.sum
@@ -63,10 +63,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c h1:T03Z7RuSyKvG+x2+sBbGdIChgQAFXbBAQCQC/y+1ap0=
-github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c h1:bqClvCTgEJeDUuL0aV3VzIxRQtVfze/lKOBL7WQZpLw=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
+github.com/getsentry/sentry-go v0.22.0 h1:XNX9zKbv7baSEI65l+H1GEJgSeIC1c7EN5kluWaP6dM=
+github.com/getsentry/sentry-go v0.22.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.22.0 h1:6ioHUtWk5IVqdIZppUI0hhm0f/+XTsT+yu6xqWCYULw=
+github.com/getsentry/sentry-go/otel v0.22.0/go.mod h1:V6d/p0sKN9OLyFeaQAx8RIc/2Uf3w6h65d+Pzx3qkmo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/productcatalogservice/go.sum
+++ b/src/productcatalogservice/go.sum
@@ -63,10 +63,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b h1:AVhL1yoan/25csLmQ4/AaqnfZpDckyIogupD2AB8ErQ=
-github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b h1:j+ft0dmibZkW/LOgdeptppZjmFV62ttNOpDt4iZt2S0=
-github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
+github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c h1:T03Z7RuSyKvG+x2+sBbGdIChgQAFXbBAQCQC/y+1ap0=
+github.com/getsentry/sentry-go v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c h1:bqClvCTgEJeDUuL0aV3VzIxRQtVfze/lKOBL7WQZpLw=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230616093838-dc695c99ba2c/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/productcatalogservice/go.sum
+++ b/src/productcatalogservice/go.sum
@@ -63,10 +63,10 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/getsentry/sentry-go v0.21.0 h1:c9l5F1nPF30JIppulk4veau90PK6Smu3abgVtVQWon4=
-github.com/getsentry/sentry-go v0.21.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.21.0 h1:0GJViLdYYDWdSJLyFe8JMx2Aq3TOVZ4OFhn5KGDjyYQ=
-github.com/getsentry/sentry-go/otel v0.21.0/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
+github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b h1:AVhL1yoan/25csLmQ4/AaqnfZpDckyIogupD2AB8ErQ=
+github.com/getsentry/sentry-go v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b h1:j+ft0dmibZkW/LOgdeptppZjmFV62ttNOpDt4iZt2S0=
+github.com/getsentry/sentry-go/otel v0.21.1-0.20230612162134-97a00a4a9d0b/go.mod h1:jrTyKi2cVvOBH6O43PWR7dfI98t8JMBU6w1tXgXUy0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/productcatalogservice/main.go
+++ b/src/productcatalogservice/main.go
@@ -49,7 +49,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/getsentry/sentry-go/otel"
+	sentryotel "github.com/getsentry/sentry-go/otel"
 )
 
 var (
@@ -116,10 +116,11 @@ func initMeterProvider() *sdkmetric.MeterProvider {
 
 func main() {
 	sentry.Init(sentry.ClientOptions{
-		Dsn:              "",
-		EnableTracing:    true,
-		TracesSampleRate: 1.0,
-		Debug:            true,
+		Dsn:                "",
+		EnableTracing:      true,
+		TracesSampleRate:   1.0,
+		ProfilesSampleRate: 1.0,
+		Debug:              true,
 	})
 
 	tp := initTracerProvider()


### PR DESCRIPTION
* Bumped to version: [v0.22.0](https://github.com/getsentry/sentry-go/releases/tag/v0.22.0).
* Enabled Profiling for Go services