### PR TITLE
feat: Bump sentry-go to 0.24.0

### DIFF
--- a/src/accountingservice/go.mod
+++ b/src/accountingservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.38.1
-	github.com/getsentry/sentry-go v0.22.0
-	github.com/getsentry/sentry-go/otel v0.22.0
+	github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a
+	github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a
 	github.com/golang/protobuf v1.5.3
 	github.com/sirupsen/logrus v1.9.3
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.42.0

--- a/src/accountingservice/go.mod
+++ b/src/accountingservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.38.1
-	github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a
-	github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a
+	github.com/getsentry/sentry-go v0.24.0
+	github.com/getsentry/sentry-go/otel v0.24.0
 	github.com/golang/protobuf v1.5.3
 	github.com/sirupsen/logrus v1.9.3
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.42.0

--- a/src/accountingservice/go.sum
+++ b/src/accountingservice/go.sum
@@ -13,10 +13,10 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:m/5heeS7UWzN+WX08J++bXrEP2i+d/Duv2g9E9jd23c=
-github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:syamru7ZaJfK0YNtEGAl2gxOwH5YsjT37CGabXqjmFY=
-github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:2oEItOfu5gdo3eeOC0RXwUus15OVJMC9tRWLnu4ERAQ=
+github.com/getsentry/sentry-go v0.24.0 h1:02b7qEmJ56EHGe9KFgjArjU/vG/aywm7Efgu+iPc01Y=
+github.com/getsentry/sentry-go v0.24.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.24.0 h1:FdLaZJXbMuF+i/AE7JEVTbuGBZWG5HO5RV3CXxdZvtE=
+github.com/getsentry/sentry-go/otel v0.24.0/go.mod h1:r66RqOSqo43Y42zoo4LZAc+xU/V/bQFCFDiolPler1g=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=

--- a/src/accountingservice/go.sum
+++ b/src/accountingservice/go.sum
@@ -13,10 +13,10 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.22.0 h1:XNX9zKbv7baSEI65l+H1GEJgSeIC1c7EN5kluWaP6dM=
-github.com/getsentry/sentry-go v0.22.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.22.0 h1:6ioHUtWk5IVqdIZppUI0hhm0f/+XTsT+yu6xqWCYULw=
-github.com/getsentry/sentry-go/otel v0.22.0/go.mod h1:V6d/p0sKN9OLyFeaQAx8RIc/2Uf3w6h65d+Pzx3qkmo=
+github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:m/5heeS7UWzN+WX08J++bXrEP2i+d/Duv2g9E9jd23c=
+github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:syamru7ZaJfK0YNtEGAl2gxOwH5YsjT37CGabXqjmFY=
+github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:2oEItOfu5gdo3eeOC0RXwUus15OVJMC9tRWLnu4ERAQ=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.38.1
-	github.com/getsentry/sentry-go v0.22.0
-	github.com/getsentry/sentry-go/otel v0.22.0
+	github.com/getsentry/sentry-go v0.23.1-0.20230905082348-edbee8292a27
+	github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0
 	github.com/sirupsen/logrus v1.9.3

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.38.1
-	github.com/getsentry/sentry-go v0.23.1-0.20230905082348-edbee8292a27
+	github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a
 	github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0

--- a/src/checkoutservice/go.mod
+++ b/src/checkoutservice/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.38.1
-	github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a
-	github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a
+	github.com/getsentry/sentry-go v0.24.0
+	github.com/getsentry/sentry-go/otel v0.24.0
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0
 	github.com/sirupsen/logrus v1.9.3

--- a/src/checkoutservice/go.sum
+++ b/src/checkoutservice/go.sum
@@ -78,10 +78,10 @@ github.com/envoyproxy/protoc-gen-validate v0.10.1 h1:c0g45+xCJhdgFGw7a5QAfdS4byA
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:m/5heeS7UWzN+WX08J++bXrEP2i+d/Duv2g9E9jd23c=
-github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:syamru7ZaJfK0YNtEGAl2gxOwH5YsjT37CGabXqjmFY=
-github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:2oEItOfu5gdo3eeOC0RXwUus15OVJMC9tRWLnu4ERAQ=
+github.com/getsentry/sentry-go v0.24.0 h1:02b7qEmJ56EHGe9KFgjArjU/vG/aywm7Efgu+iPc01Y=
+github.com/getsentry/sentry-go v0.24.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.24.0 h1:FdLaZJXbMuF+i/AE7JEVTbuGBZWG5HO5RV3CXxdZvtE=
+github.com/getsentry/sentry-go/otel v0.24.0/go.mod h1:r66RqOSqo43Y42zoo4LZAc+xU/V/bQFCFDiolPler1g=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/checkoutservice/go.sum
+++ b/src/checkoutservice/go.sum
@@ -80,8 +80,6 @@ github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:m/5heeS7UWzN+WX08J++bXrEP2i+d/Duv2g9E9jd23c=
 github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go v0.23.1-0.20230905082348-edbee8292a27 h1:bR1cp4ChJ+NBG8TX3SCU5J62ZFAGydJXQkzI0MnEwec=
-github.com/getsentry/sentry-go v0.23.1-0.20230905082348-edbee8292a27/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:syamru7ZaJfK0YNtEGAl2gxOwH5YsjT37CGabXqjmFY=
 github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:2oEItOfu5gdo3eeOC0RXwUus15OVJMC9tRWLnu4ERAQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/src/checkoutservice/go.sum
+++ b/src/checkoutservice/go.sum
@@ -78,10 +78,12 @@ github.com/envoyproxy/protoc-gen-validate v0.10.1 h1:c0g45+xCJhdgFGw7a5QAfdS4byA
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
-github.com/getsentry/sentry-go v0.22.0 h1:XNX9zKbv7baSEI65l+H1GEJgSeIC1c7EN5kluWaP6dM=
-github.com/getsentry/sentry-go v0.22.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.22.0 h1:6ioHUtWk5IVqdIZppUI0hhm0f/+XTsT+yu6xqWCYULw=
-github.com/getsentry/sentry-go/otel v0.22.0/go.mod h1:V6d/p0sKN9OLyFeaQAx8RIc/2Uf3w6h65d+Pzx3qkmo=
+github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:m/5heeS7UWzN+WX08J++bXrEP2i+d/Duv2g9E9jd23c=
+github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go v0.23.1-0.20230905082348-edbee8292a27 h1:bR1cp4ChJ+NBG8TX3SCU5J62ZFAGydJXQkzI0MnEwec=
+github.com/getsentry/sentry-go v0.23.1-0.20230905082348-edbee8292a27/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:syamru7ZaJfK0YNtEGAl2gxOwH5YsjT37CGabXqjmFY=
+github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:2oEItOfu5gdo3eeOC0RXwUus15OVJMC9tRWLnu4ERAQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/src/productcatalogservice/go.mod
+++ b/src/productcatalogservice/go.mod
@@ -10,8 +10,8 @@ require (
 )
 
 require (
-	github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a
-	github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a
+	github.com/getsentry/sentry-go v0.24.0
+	github.com/getsentry/sentry-go/otel v0.24.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.39.0
 	go.opentelemetry.io/otel/sdk v1.16.0

--- a/src/productcatalogservice/go.mod
+++ b/src/productcatalogservice/go.mod
@@ -10,8 +10,8 @@ require (
 )
 
 require (
-	github.com/getsentry/sentry-go v0.22.0
-	github.com/getsentry/sentry-go/otel v0.22.0
+	github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a
+	github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.39.0
 	go.opentelemetry.io/otel/sdk v1.16.0

--- a/src/productcatalogservice/go.sum
+++ b/src/productcatalogservice/go.sum
@@ -696,11 +696,10 @@ github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzP
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
-github.com/getsentry/sentry-go v0.23.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:m/5heeS7UWzN+WX08J++bXrEP2i+d/Duv2g9E9jd23c=
-github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:syamru7ZaJfK0YNtEGAl2gxOwH5YsjT37CGabXqjmFY=
-github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:2oEItOfu5gdo3eeOC0RXwUus15OVJMC9tRWLnu4ERAQ=
+github.com/getsentry/sentry-go v0.24.0 h1:02b7qEmJ56EHGe9KFgjArjU/vG/aywm7Efgu+iPc01Y=
+github.com/getsentry/sentry-go v0.24.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.24.0 h1:FdLaZJXbMuF+i/AE7JEVTbuGBZWG5HO5RV3CXxdZvtE=
+github.com/getsentry/sentry-go/otel v0.24.0/go.mod h1:r66RqOSqo43Y42zoo4LZAc+xU/V/bQFCFDiolPler1g=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.8.1/go.mod h1:ji8BvRH1azfM+SYow9zQ6SZMvR8qOMZHmsCuWR9tTTk=

--- a/src/productcatalogservice/go.sum
+++ b/src/productcatalogservice/go.sum
@@ -696,10 +696,11 @@ github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzP
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
-github.com/getsentry/sentry-go v0.22.0 h1:XNX9zKbv7baSEI65l+H1GEJgSeIC1c7EN5kluWaP6dM=
-github.com/getsentry/sentry-go v0.22.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
-github.com/getsentry/sentry-go/otel v0.22.0 h1:6ioHUtWk5IVqdIZppUI0hhm0f/+XTsT+yu6xqWCYULw=
-github.com/getsentry/sentry-go/otel v0.22.0/go.mod h1:V6d/p0sKN9OLyFeaQAx8RIc/2Uf3w6h65d+Pzx3qkmo=
+github.com/getsentry/sentry-go v0.23.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:m/5heeS7UWzN+WX08J++bXrEP2i+d/Duv2g9E9jd23c=
+github.com/getsentry/sentry-go v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a h1:syamru7ZaJfK0YNtEGAl2gxOwH5YsjT37CGabXqjmFY=
+github.com/getsentry/sentry-go/otel v0.23.1-0.20230905081744-fe4e7d6a8f2a/go.mod h1:2oEItOfu5gdo3eeOC0RXwUus15OVJMC9tRWLnu4ERAQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.8.1/go.mod h1:ji8BvRH1azfM+SYow9zQ6SZMvR8qOMZHmsCuWR9tTTk=


### PR DESCRIPTION
~Revision: https://github.com/getsentry/sentry-go/commit/fe4e7d6a8f2a8de0a12f457c885cd77019d4fb26~

Bumping sentry-go to the latest release (0.24.0).